### PR TITLE
Use `PublishJson` from outside the crate

### DIFF
--- a/src/publish.rs
+++ b/src/publish.rs
@@ -136,6 +136,17 @@ pub struct PublishJson<'a, T, D: serde::Serialize> {
     pub(crate) retain: bool,
 }
 
+impl <'a, T, D: serde::Serialize> PublishJson<'a, T, D> {
+
+    /// Create new `PublishJson` with given topic, data, QoS and retain
+    pub fn new(topic: &'a Topic<T>, data: D, qos: QoS, retain: bool) -> Self {
+        Self {
+            topic, data, qos, retain
+        }
+    }
+
+}
+
 #[cfg(feature = "serde")]
 impl<T, D: serde::Serialize> PublishJson<'_, T, D> {
     /// Sets the QoS level for this message.

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -136,6 +136,7 @@ pub struct PublishJson<'a, T, D: serde::Serialize> {
     pub(crate) retain: bool,
 }
 
+#[cfg(feature = "serde")]
 impl <'a, T, D: serde::Serialize> PublishJson<'a, T, D> {
 
     /// Create new `PublishJson` with given topic, data, QoS and retain


### PR DESCRIPTION
`PublishJson` is not constructible from outside the crate because the fields are only `pub(crate)`. I asses a `PublishJson::new()` function to allow the construction of `PublishJson` from outside the crate.